### PR TITLE
[JOJI-415] feat: 할일 목록을 추가하는 기능 작성

### DIFF
--- a/src/app/todo-list/project/page.js
+++ b/src/app/todo-list/project/page.js
@@ -1,3 +1,14 @@
+"use client";
+
+import { TodoList } from "@/components/TodoList";
+
 export default function TodoListProjectPage() {
-  return <div>TodoListProjectPage</div>;
+  return (
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <main className="flex flex-col gap-8 row-start-2 items-center">
+        <TodoList />
+      </main>
+      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center"></footer>
+    </div>
+  );
 }

--- a/src/app/todo-list/project/page.js
+++ b/src/app/todo-list/project/page.js
@@ -1,0 +1,3 @@
+export default function TodoListProjectPage() {
+  return <div>TodoListProjectPage</div>;
+}

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+/**
+ * @typedef {Object} Todo
+ * @property {string} id
+ * @property {string} title
+ * @property {boolean} isDone
+ */
+
+export function TodoList() {
+  /**
+   * @type {Todo[]}
+   */
+  const [todoList, setTodoList] = useState([]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const title = e.target.title.value;
+    if (!title) return;
+    setTodoList([...todoList, { id: Date.now(), title, isDone: false }]);
+    e.target.title.value = "";
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input name="title" type="text" className="border text-black" />
+        <button className="border p-2">추가</button>
+      </form>
+
+      <ul className="flex flex-col gap-2">
+        {todoList.map((todo) => (
+          <li key={todo.id}>{todo.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 
 export function TodoList() {
   /**
-   * @type {Todo[]}
+   * @type {[Todo[], (todoList: Todo[]) => void]}
    */
   const [todoList, setTodoList] = useState([]);
 

--- a/src/guide/ProjectSpecification.jsx
+++ b/src/guide/ProjectSpecification.jsx
@@ -16,11 +16,17 @@ import { useEffect, useState } from "react";
  */
 
 /**
+ * @typedef {Object} ProjectSpecificationProps
+ * @property {string} projectName - 프로젝트 이름
+ * @property {string} projectPurpose - 프로젝트 목적
+ * @property {Assignment[]} assignmentList - 과제 목록
+ * @property {Reference[]} referenceLinks - 참고할만한 링크
+ */
+
+/**
  * 프로젝트 스펙 컴포넌트
- * @param {string} projectName - 프로젝트 이름
- * @param {string} projectPurpose - 프로젝트 목적
- * @param {Assignment[]} assignmentList - 과제 목록
- * @param {Reference[]} referenceLinks - 참고할만한 링크
+ * @type {React.FC<ProjectSpecificationProps>}
+ * @param {ProjectSpecificationProps} props - 프로젝트 스펙 컴포넌트 속성
  * @returns {JSX.Element} - 프로젝트 스펙 컴포넌트
  */
 export function ProjectSpecification({


### PR DESCRIPTION
## 요약

할일 목록을 추가할 수 있는 기능을 구현하였습니다.

## 작업 내용

- [feat: 투두리스트 페이지 생성](https://github.com/joji-company-dev/tutorial1-todo-list/pull/1/commits/d257dafbbf22a48d664287516c76303801bca04a)
- [feat: 할일 목록을 추가할 수 있는 TodoList 컴포넌트 작성](https://github.com/joji-company-dev/tutorial1-todo-list/pull/1/commits/6d0b27f8cfd228bd532d260f77cad3d7ad802e68)

## 기타 사항

- 오랜만에 투두리스트 구현하니 재밌네요 ㅎㅎ

## 스크린샷

![image](https://github.com/user-attachments/assets/d4e3f55e-9a2a-4e61-8869-564e99962836)

